### PR TITLE
All remaining changes for contracts to compile with 0.5.0

### DIFF
--- a/contracts/bounties/BreakInvariantBounty.sol
+++ b/contracts/bounties/BreakInvariantBounty.sol
@@ -11,7 +11,7 @@ contract BreakInvariantBounty is PullPayment, Ownable {
   bool private _claimed;
   mapping(address => address) private _researchers;
 
-  event TargetCreated(address createdAddress);
+  event TargetCreated(Target createdAddress);
 
   /**
    * @dev Fallback function allowing the contract to receive funds, if they haven't already been claimed.
@@ -35,7 +35,7 @@ contract BreakInvariantBounty is PullPayment, Ownable {
    */
   function createTarget() public returns(Target) {
     Target target = Target(_deployContract());
-    _researchers[target] = msg.sender;
+    _researchers[address(target)] = msg.sender;
     emit TargetCreated(target);
     return target;
   }
@@ -45,7 +45,7 @@ contract BreakInvariantBounty is PullPayment, Ownable {
    * @param target contract
    */
   function claim(Target target) public {
-    address researcher = _researchers[target];
+    address researcher = _researchers[address(target)];
     require(researcher != address(0));
     // Check Target contract invariants
     require(!target.checkInvariant());
@@ -57,7 +57,8 @@ contract BreakInvariantBounty is PullPayment, Ownable {
    * @dev Transfers the current balance to the owner and terminates the contract.
    */
   function destroy() public onlyOwner {
-    selfdestruct(owner());
+    // ToDo: Check this
+    selfdestruct(address(uint160(owner())));
   }
 
   /**

--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -24,7 +24,7 @@ contract Crowdsale {
   IERC20 private _token;
 
   // Address where funds are collected
-  address private _wallet;
+  address payable private _wallet;
 
   // How many token units a buyer gets per wei.
   // The rate is the conversion between wei and the smallest and indivisible token unit.
@@ -57,10 +57,10 @@ contract Crowdsale {
    * @param wallet Address where collected funds will be forwarded to
    * @param token Address of the token being sold
    */
-  constructor(uint256 rate, address wallet, IERC20 token) public {
+  constructor(uint256 rate, address payable wallet, IERC20 token) public {
     require(rate > 0);
     require(wallet != address(0));
-    require(token != address(0));
+    require(address(token) != address(0));
 
     _rate = rate;
     _wallet = wallet;
@@ -88,7 +88,7 @@ contract Crowdsale {
   /**
    * @return the address where funds are collected.
    */
-  function wallet() public view returns(address) {
+  function wallet() public view returns(address payable) {
     return _wallet;
   }
 

--- a/contracts/crowdsale/distribution/RefundableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundableCrowdsale.sol
@@ -39,7 +39,7 @@ contract RefundableCrowdsale is FinalizableCrowdsale {
    * @dev Investors can claim refunds here if crowdsale is unsuccessful
    * @param beneficiary Whose refund will be claimed.
    */
-  function claimRefund(address beneficiary) public {
+  function claimRefund(address payable beneficiary) public {
     require(finalized());
     require(!goalReached());
 

--- a/contracts/cryptography/ECDSA.sol
+++ b/contracts/cryptography/ECDSA.sol
@@ -14,7 +14,7 @@ library ECDSA {
    * @param hash bytes32 message, the hash is the signed message. What is recovered is the signer address.
    * @param signature bytes signature, the signature is generated using web3.eth.sign()
    */
-  function recover(bytes32 hash, bytes signature)
+  function recover(bytes32 hash, bytes memory signature)
     internal
     pure
     returns (address)

--- a/contracts/cryptography/MerkleProof.sol
+++ b/contracts/cryptography/MerkleProof.sol
@@ -14,7 +14,7 @@ library MerkleProof {
    * @param leaf Leaf of Merkle tree
    */
   function verify(
-    bytes32[] proof,
+    bytes32[] memory proof,
     bytes32 root,
     bytes32 leaf
   )

--- a/contracts/drafts/ERC1046/TokenMetadata.sol
+++ b/contracts/drafts/ERC1046/TokenMetadata.sol
@@ -9,19 +9,19 @@ import "../../token/ERC20/IERC20.sol";
  * @dev TODO - update https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC721/IERC721.sol#L17 when 1046 is finalized
  */
 contract ERC20TokenMetadata is IERC20 {
-  function tokenURI() external view returns (string);
+  function tokenURI() external view returns (string memory);
 }
 
 contract ERC20WithMetadata is ERC20TokenMetadata {
   string private _tokenURI = "";
 
-  constructor(string tokenURI)
+  constructor(string memory tokenURI)
     public
   {
     _tokenURI = tokenURI;
   }
 
-  function tokenURI() external view returns (string) {
+  function tokenURI() external view returns (string memory) {
     return _tokenURI;
   }
 }

--- a/contracts/drafts/ERC20Migrator.sol
+++ b/contracts/drafts/ERC20Migrator.sol
@@ -44,7 +44,7 @@ contract ERC20Migrator {
    * @param legacyToken address of the old token contract
    */
   constructor(IERC20 legacyToken) public {
-    require(legacyToken != address(0));
+    require(address(legacyToken) != address(0));
     _legacyToken = legacyToken;
   }
 
@@ -68,9 +68,9 @@ contract ERC20Migrator {
    * @param newToken the token that will be minted
    */
   function beginMigration(ERC20Mintable newToken) public {
-    require(_newToken == address(0));
-    require(newToken != address(0));
-    require(newToken.isMinter(this));
+    require(address(_newToken) == address(0));
+    require(address(newToken) != address(0));
+    require(newToken.isMinter(address(this)));
 
     _newToken = newToken;
   }
@@ -82,7 +82,7 @@ contract ERC20Migrator {
    * @param amount amount of tokens to be migrated
    */
   function migrate(address account, uint256 amount) public {
-    _legacyToken.safeTransferFrom(account, this, amount);
+    _legacyToken.safeTransferFrom(account, address(this), amount);
     _newToken.mint(account, amount);
   }
 
@@ -93,7 +93,7 @@ contract ERC20Migrator {
    */
   function migrateAll(address account) public {
     uint256 balance = _legacyToken.balanceOf(account);
-    uint256 allowance = _legacyToken.allowance(account, this);
+    uint256 allowance = _legacyToken.allowance(account, address(this));
     uint256 amount = Math.min(balance, allowance);
     migrate(account, amount);
   }

--- a/contracts/drafts/SignatureBouncer.sol
+++ b/contracts/drafts/SignatureBouncer.sol
@@ -39,7 +39,7 @@ contract SignatureBouncer is SignerRole {
   /**
    * @dev requires that a valid signature of a signer was provided
    */
-  modifier onlyValidSignature(bytes signature)
+  modifier onlyValidSignature(bytes memory signature)
   {
     require(_isValidSignature(msg.sender, signature));
     _;
@@ -48,7 +48,7 @@ contract SignatureBouncer is SignerRole {
   /**
    * @dev requires that a valid signature with a specifed method of a signer was provided
    */
-  modifier onlyValidSignatureAndMethod(bytes signature)
+  modifier onlyValidSignatureAndMethod(bytes memory signature)
   {
     require(_isValidSignatureAndMethod(msg.sender, signature));
     _;
@@ -57,7 +57,7 @@ contract SignatureBouncer is SignerRole {
   /**
    * @dev requires that a valid signature with a specifed method and params of a signer was provided
    */
-  modifier onlyValidSignatureAndData(bytes signature)
+  modifier onlyValidSignatureAndData(bytes memory signature)
   {
     require(_isValidSignatureAndData(msg.sender, signature));
     _;
@@ -67,7 +67,7 @@ contract SignatureBouncer is SignerRole {
    * @dev is the signature of `this + sender` from a signer?
    * @return bool
    */
-  function _isValidSignature(address account, bytes signature)
+  function _isValidSignature(address account, bytes memory signature)
     internal
     view
     returns (bool)
@@ -82,7 +82,7 @@ contract SignatureBouncer is SignerRole {
    * @dev is the signature of `this + sender + methodId` from a signer?
    * @return bool
    */
-  function _isValidSignatureAndMethod(address account, bytes signature)
+  function _isValidSignatureAndMethod(address account, bytes memory signature)
     internal
     view
     returns (bool)
@@ -102,7 +102,7 @@ contract SignatureBouncer is SignerRole {
     * @notice the signature parameter of the method being validated must be the "last" parameter
     * @return bool
     */
-  function _isValidSignatureAndData(address account, bytes signature)
+  function _isValidSignatureAndData(address account, bytes memory signature)
     internal
     view
     returns (bool)
@@ -123,7 +123,7 @@ contract SignatureBouncer is SignerRole {
    * and then recover the signature and check it against the signer role
    * @return bool
    */
-  function _isValidDataHash(bytes32 hash, bytes signature)
+  function _isValidDataHash(bytes32 hash, bytes memory signature)
     internal
     view
     returns (bool)

--- a/contracts/drafts/TokenVesting.sol
+++ b/contracts/drafts/TokenVesting.sol
@@ -118,7 +118,7 @@ contract TokenVesting is Ownable {
 
     require(unreleased > 0);
 
-    _released[token] = _released[token].add(unreleased);
+    _released[address(token)] = _released[address(token)].add(unreleased);
 
     token.safeTransfer(_beneficiary, unreleased);
 
@@ -132,14 +132,14 @@ contract TokenVesting is Ownable {
    */
   function revoke(IERC20 token) public onlyOwner {
     require(_revocable);
-    require(!_revoked[token]);
+    require(!_revoked[address(token)]);
 
     uint256 balance = token.balanceOf(address(this));
 
     uint256 unreleased = releasableAmount(token);
     uint256 refund = balance.sub(unreleased);
 
-    _revoked[token] = true;
+    _revoked[address(token)] = true;
 
     token.safeTransfer(owner(), refund);
 
@@ -151,7 +151,7 @@ contract TokenVesting is Ownable {
    * @param token ERC20 token which is being vested
    */
   function releasableAmount(IERC20 token) public view returns (uint256) {
-    return vestedAmount(token).sub(_released[token]);
+    return vestedAmount(token).sub(_released[address(token)]);
   }
 
   /**
@@ -159,12 +159,12 @@ contract TokenVesting is Ownable {
    * @param token ERC20 token which is being vested
    */
   function vestedAmount(IERC20 token) public view returns (uint256) {
-    uint256 currentBalance = token.balanceOf(this);
-    uint256 totalBalance = currentBalance.add(_released[token]);
+    uint256 currentBalance = token.balanceOf(address(this));
+    uint256 totalBalance = currentBalance.add(_released[address(token)]);
 
     if (block.timestamp < _cliff) {
       return 0;
-    } else if (block.timestamp >= _start.add(_duration) || _revoked[token]) {
+    } else if (block.timestamp >= _start.add(_duration) || _revoked[address(token)]) {
       return totalBalance;
     } else {
       return totalBalance.mul(block.timestamp.sub(_start)).div(_duration);

--- a/contracts/examples/SampleCrowdsale.sol
+++ b/contracts/examples/SampleCrowdsale.sol
@@ -39,7 +39,7 @@ contract SampleCrowdsale is CappedCrowdsale, RefundableCrowdsale, MintedCrowdsal
     uint256 openingTime,
     uint256 closingTime,
     uint256 rate,
-    address wallet,
+    address payable wallet,
     uint256 cap,
     ERC20Mintable token,
     uint256 goal

--- a/contracts/introspection/ERC165Checker.sol
+++ b/contracts/introspection/ERC165Checker.sol
@@ -57,7 +57,7 @@ library ERC165Checker {
    * interfaceIds list, false otherwise
    * @dev Interface identification is specified in ERC-165.
    */
-  function supportsInterfaces(address account, bytes4[] interfaceIds)
+  function supportsInterfaces(address account, bytes4[] memory interfaceIds)
     internal
     view
     returns (bool)

--- a/contracts/mocks/AllowanceCrowdsaleImpl.sol
+++ b/contracts/mocks/AllowanceCrowdsaleImpl.sol
@@ -7,7 +7,7 @@ contract AllowanceCrowdsaleImpl is AllowanceCrowdsale {
 
   constructor (
     uint256 rate,
-    address wallet,
+    address payable wallet,
     IERC20 token,
     address tokenWallet
   )

--- a/contracts/mocks/BreakInvariantBountyMock.sol
+++ b/contracts/mocks/BreakInvariantBountyMock.sol
@@ -23,6 +23,6 @@ contract TargetMock is Target {
 
 contract BreakInvariantBountyMock is BreakInvariantBounty {
   function _deployContract() internal returns (address) {
-    return new TargetMock();
+    return address(new TargetMock());
   }
 }

--- a/contracts/mocks/CappedCrowdsaleImpl.sol
+++ b/contracts/mocks/CappedCrowdsaleImpl.sol
@@ -7,7 +7,7 @@ contract CappedCrowdsaleImpl is CappedCrowdsale {
 
   constructor (
     uint256 rate,
-    address wallet,
+    address payable wallet,
     IERC20 token,
     uint256 cap
   )

--- a/contracts/mocks/CounterImpl.sol
+++ b/contracts/mocks/CounterImpl.sol
@@ -10,7 +10,7 @@ contract CounterImpl {
   // use whatever key you want to track your counters
   mapping(string => Counter.Counter) private _counters;
 
-  function doThing(string key)
+  function doThing(string memory key)
     public
     returns (uint256)
   {

--- a/contracts/mocks/DetailedERC20Mock.sol
+++ b/contracts/mocks/DetailedERC20Mock.sol
@@ -5,8 +5,8 @@ import "../token/ERC20/ERC20Detailed.sol";
 
 contract ERC20DetailedMock is ERC20, ERC20Detailed {
   constructor(
-    string name,
-    string symbol,
+    string memory name,
+    string memory symbol,
     uint8 decimals
   )
     ERC20Detailed(name, symbol, decimals)

--- a/contracts/mocks/ECDSAMock.sol
+++ b/contracts/mocks/ECDSAMock.sol
@@ -5,7 +5,7 @@ import "../cryptography/ECDSA.sol";
 contract ECDSAMock {
   using ECDSA for bytes32;
 
-  function recover(bytes32 hash, bytes signature)
+  function recover(bytes32 hash, bytes memory signature)
     public
     pure
     returns (address)

--- a/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
+++ b/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
@@ -56,7 +56,7 @@ contract SupportsInterfaceWithLookupMock is IERC165 {
 }
 
 contract ERC165InterfacesSupported is SupportsInterfaceWithLookupMock {
-  constructor (bytes4[] interfaceIds)
+  constructor (bytes4[] memory interfaceIds)
     public
   {
     for (uint256 i = 0; i < interfaceIds.length; i++) {

--- a/contracts/mocks/ERC165CheckerMock.sol
+++ b/contracts/mocks/ERC165CheckerMock.sol
@@ -21,7 +21,7 @@ contract ERC165CheckerMock {
     return account.supportsInterface(interfaceId);
   }
 
-  function supportsInterfaces(address account, bytes4[] interfaceIds)
+  function supportsInterfaces(address account, bytes4[] memory interfaceIds)
     public
     view
     returns (bool)

--- a/contracts/mocks/ERC20WithMetadataMock.sol
+++ b/contracts/mocks/ERC20WithMetadataMock.sol
@@ -4,7 +4,7 @@ import "../token/ERC20/ERC20.sol";
 import "../drafts/ERC1046/TokenMetadata.sol";
 
 contract ERC20WithMetadataMock is ERC20, ERC20WithMetadata {
-  constructor(string tokenURI) public
+  constructor(string memory tokenURI) public
     ERC20WithMetadata(tokenURI)
   {
   }

--- a/contracts/mocks/ERC721FullMock.sol
+++ b/contracts/mocks/ERC721FullMock.sol
@@ -10,7 +10,7 @@ import "../token/ERC721/ERC721Burnable.sol";
  * and a public setter for metadata URI
  */
 contract ERC721FullMock is ERC721Full, ERC721Mintable, ERC721Burnable {
-  constructor(string name, string symbol) public
+  constructor(string memory name, string memory symbol) public
     ERC721Mintable()
     ERC721Full(name, symbol)
   {}
@@ -19,7 +19,7 @@ contract ERC721FullMock is ERC721Full, ERC721Mintable, ERC721Burnable {
     return _exists(tokenId);
   }
 
-  function setTokenURI(uint256 tokenId, string uri) public {
+  function setTokenURI(uint256 tokenId, string memory uri) public {
     _setTokenURI(tokenId, uri);
   }
 

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -23,7 +23,7 @@ contract ERC721ReceiverMock is IERC721Receiver {
     address operator,
     address from,
     uint256 tokenId,
-    bytes data
+    bytes memory data
   )
     public
     returns(bytes4)

--- a/contracts/mocks/FinalizableCrowdsaleImpl.sol
+++ b/contracts/mocks/FinalizableCrowdsaleImpl.sol
@@ -9,7 +9,7 @@ contract FinalizableCrowdsaleImpl is FinalizableCrowdsale {
     uint256 openingTime,
     uint256 closingTime,
     uint256 rate,
-    address wallet,
+    address payable wallet,
     IERC20 token
   )
     public

--- a/contracts/mocks/ForceEther.sol
+++ b/contracts/mocks/ForceEther.sol
@@ -9,7 +9,7 @@ contract ForceEther {
 
   constructor() public payable { }
 
-  function destroyAndSend(address recipient) public {
+  function destroyAndSend(address payable recipient) public {
     selfdestruct(recipient);
   }
 }

--- a/contracts/mocks/IncreasingPriceCrowdsaleImpl.sol
+++ b/contracts/mocks/IncreasingPriceCrowdsaleImpl.sol
@@ -8,7 +8,7 @@ contract IncreasingPriceCrowdsaleImpl is IncreasingPriceCrowdsale {
   constructor (
     uint256 openingTime,
     uint256 closingTime,
-    address wallet,
+    address payable wallet,
     IERC20 token,
     uint256 initialRate,
     uint256 finalRate

--- a/contracts/mocks/IndividuallyCappedCrowdsaleImpl.sol
+++ b/contracts/mocks/IndividuallyCappedCrowdsaleImpl.sol
@@ -9,7 +9,7 @@ contract IndividuallyCappedCrowdsaleImpl
 
   constructor(
     uint256 rate,
-    address wallet,
+    address payable wallet,
     IERC20 token
   )
     public

--- a/contracts/mocks/MerkleProofWrapper.sol
+++ b/contracts/mocks/MerkleProofWrapper.sol
@@ -5,7 +5,7 @@ import { MerkleProof } from "../cryptography/MerkleProof.sol";
 contract MerkleProofWrapper {
 
   function verify(
-    bytes32[] proof,
+    bytes32[] memory proof,
     bytes32 root,
     bytes32 leaf
   )

--- a/contracts/mocks/MessageHelper.sol
+++ b/contracts/mocks/MessageHelper.sol
@@ -8,7 +8,7 @@ contract MessageHelper {
   function showMessage(
     bytes32 _message,
     uint256 _number,
-    string _text
+    string memory _text
   )
     public
     returns (bool)
@@ -20,7 +20,7 @@ contract MessageHelper {
   function buyMessage(
     bytes32 _message,
     uint256 _number,
-    string _text
+    string memory _text
   )
     public
     payable
@@ -38,12 +38,10 @@ contract MessageHelper {
     require(false);
   }
 
-  function call(address _to, bytes _data) public returns (bool) {
+  function call(address _to, bytes memory _data) public returns (bool) {
     // solium-disable-next-line security/no-low-level-calls
-    if (_to.call(_data))
-      return true;
-    else
-      return false;
+    (bool success,) = _to.call(_data);
+    return success;
   }
 
 }

--- a/contracts/mocks/MintedCrowdsaleImpl.sol
+++ b/contracts/mocks/MintedCrowdsaleImpl.sol
@@ -7,7 +7,7 @@ contract MintedCrowdsaleImpl is MintedCrowdsale {
 
   constructor (
     uint256 rate,
-    address wallet,
+    address payable wallet,
     ERC20Mintable token
   )
     public

--- a/contracts/mocks/PostDeliveryCrowdsaleImpl.sol
+++ b/contracts/mocks/PostDeliveryCrowdsaleImpl.sol
@@ -9,7 +9,7 @@ contract PostDeliveryCrowdsaleImpl is PostDeliveryCrowdsale {
     uint256 openingTime,
     uint256 closingTime,
     uint256 rate,
-    address wallet,
+    address payable wallet,
     IERC20 token
   )
     public

--- a/contracts/mocks/ReentrancyAttack.sol
+++ b/contracts/mocks/ReentrancyAttack.sol
@@ -4,7 +4,8 @@ contract ReentrancyAttack {
 
   function callSender(bytes4 data) public {
     // solium-disable-next-line security/no-low-level-calls
-    require(msg.sender.call(abi.encodeWithSelector(data)));
+    (bool success,) = msg.sender.call(abi.encodeWithSelector(data));
+    require(success);
   }
 
 }

--- a/contracts/mocks/ReentrancyMock.sol
+++ b/contracts/mocks/ReentrancyMock.sol
@@ -26,7 +26,7 @@ contract ReentrancyMock is ReentrancyGuard {
     if (n > 0) {
       count();
       // solium-disable-next-line security/no-low-level-calls
-      bool result = address(this).call(abi.encodeWithSignature("countThisRecursive(uint256)", n - 1));
+      (bool result,) = address(this).call(abi.encodeWithSignature("countThisRecursive(uint256)", n - 1));
       require(result == true);
     }
   }

--- a/contracts/mocks/RefundableCrowdsaleImpl.sol
+++ b/contracts/mocks/RefundableCrowdsaleImpl.sol
@@ -9,7 +9,7 @@ contract RefundableCrowdsaleImpl is RefundableCrowdsale {
     uint256 openingTime,
     uint256 closingTime,
     uint256 rate,
-    address wallet,
+    address payable wallet,
     ERC20Mintable token,
     uint256 goal
   )

--- a/contracts/mocks/SignatureBouncerMock.sol
+++ b/contracts/mocks/SignatureBouncerMock.sol
@@ -4,7 +4,7 @@ import "../drafts/SignatureBouncer.sol";
 import "./SignerRoleMock.sol";
 
 contract SignatureBouncerMock is SignatureBouncer, SignerRoleMock {
-  function checkValidSignature(address account, bytes signature)
+  function checkValidSignature(address account, bytes memory signature)
     public
     view
     returns (bool)
@@ -12,7 +12,7 @@ contract SignatureBouncerMock is SignatureBouncer, SignerRoleMock {
     return _isValidSignature(account, signature);
   }
 
-  function onlyWithValidSignature(bytes signature)
+  function onlyWithValidSignature(bytes memory signature)
     public
     onlyValidSignature(signature)
     view
@@ -20,7 +20,7 @@ contract SignatureBouncerMock is SignatureBouncer, SignerRoleMock {
 
   }
 
-  function checkValidSignatureAndMethod(address account, bytes signature)
+  function checkValidSignatureAndMethod(address account, bytes memory signature)
     public
     view
     returns (bool)
@@ -28,7 +28,7 @@ contract SignatureBouncerMock is SignatureBouncer, SignerRoleMock {
     return _isValidSignatureAndMethod(account, signature);
   }
 
-  function onlyWithValidSignatureAndMethod(bytes signature)
+  function onlyWithValidSignatureAndMethod(bytes memory signature)
     public
     onlyValidSignatureAndMethod(signature)
     view
@@ -38,9 +38,9 @@ contract SignatureBouncerMock is SignatureBouncer, SignerRoleMock {
 
   function checkValidSignatureAndData(
     address account,
-    bytes,
+    bytes memory,
     uint,
-    bytes signature
+    bytes memory signature
   )
     public
     view
@@ -49,7 +49,7 @@ contract SignatureBouncerMock is SignatureBouncer, SignerRoleMock {
     return _isValidSignatureAndData(account, signature);
   }
 
-  function onlyWithValidSignatureAndData(uint, bytes signature)
+  function onlyWithValidSignatureAndData(uint, bytes memory signature)
     public
     onlyValidSignatureAndData(signature)
     view
@@ -57,7 +57,7 @@ contract SignatureBouncerMock is SignatureBouncer, SignerRoleMock {
 
   }
 
-  function theWrongMethod(bytes)
+  function theWrongMethod(bytes memory)
     public
     pure
   {

--- a/contracts/mocks/TimedCrowdsaleImpl.sol
+++ b/contracts/mocks/TimedCrowdsaleImpl.sol
@@ -9,7 +9,7 @@ contract TimedCrowdsaleImpl is TimedCrowdsale {
     uint256 openingTime,
     uint256 closingTime,
     uint256 rate,
-    address wallet,
+    address payable wallet,
     IERC20 token
   )
     public

--- a/contracts/payment/ConditionalEscrow.sol
+++ b/contracts/payment/ConditionalEscrow.sol
@@ -14,7 +14,7 @@ contract ConditionalEscrow is Escrow {
   */
   function withdrawalAllowed(address payee) public view returns (bool);
 
-  function withdraw(address payee) public {
+  function withdraw(address payable payee) public {
     require(withdrawalAllowed(payee));
     super.withdraw(payee);
   }

--- a/contracts/payment/Escrow.sol
+++ b/contracts/payment/Escrow.sol
@@ -37,7 +37,7 @@ contract Escrow is Secondary {
   * @dev Withdraw accumulated balance for a payee.
   * @param payee The address whose funds will be withdrawn and transferred to.
   */
-  function withdraw(address payee) public onlyPrimary {
+  function withdraw(address payable payee) public onlyPrimary {
     uint256 payment = _deposits[payee];
 
     _deposits[payee] = 0;

--- a/contracts/payment/PullPayment.sol
+++ b/contracts/payment/PullPayment.sol
@@ -18,7 +18,7 @@ contract PullPayment {
   * @dev Withdraw accumulated balance.
   * @param payee Whose balance will be withdrawn.
   */
-  function withdrawPayments(address payee) public {
+  function withdrawPayments(address payable payee) public {
     _escrow.withdraw(payee);
   }
 

--- a/contracts/payment/RefundEscrow.sol
+++ b/contracts/payment/RefundEscrow.sol
@@ -16,13 +16,13 @@ contract RefundEscrow is Secondary, ConditionalEscrow {
   event RefundsEnabled();
 
   State private _state;
-  address private _beneficiary;
+  address payable private _beneficiary;
 
   /**
    * @dev Constructor.
    * @param beneficiary The beneficiary of the deposits.
    */
-  constructor(address beneficiary) public {
+  constructor(address payable beneficiary) public {
     require(beneficiary != address(0));
     _beneficiary = beneficiary;
     _state = State.Active;
@@ -38,7 +38,7 @@ contract RefundEscrow is Secondary, ConditionalEscrow {
   /**
    * @return the beneficiary of the escrow.
    */
-  function beneficiary() public view returns (address) {
+  function beneficiary() public view returns (address payable) {
     return _beneficiary;
   }
 

--- a/contracts/payment/SplitPayment.sol
+++ b/contracts/payment/SplitPayment.sol
@@ -20,7 +20,7 @@ contract SplitPayment {
   /**
    * @dev Constructor
    */
-  constructor(address[] payees, uint256[] shares) public payable {
+  constructor(address[] memory payees, uint256[] memory shares) public payable {
     require(payees.length == shares.length);
     require(payees.length > 0);
 
@@ -73,7 +73,7 @@ contract SplitPayment {
    * @dev Release one of the payee's proportional payment.
    * @param account Whose payments will be released.
    */
-  function release(address account) public {
+  function release(address payable account) public {
     require(_shares[account] > 0);
 
     uint256 totalReceived = address(this).balance.add(_totalReleased);

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -165,7 +165,7 @@ contract ERC20 is IERC20 {
    * @param amount The amount that will be created.
    */
   function _mint(address account, uint256 amount) internal {
-    require(account != 0);
+    require(account != address(0));
     _totalSupply = _totalSupply.add(amount);
     _balances[account] = _balances[account].add(amount);
     emit Transfer(address(0), account, amount);
@@ -178,7 +178,7 @@ contract ERC20 is IERC20 {
    * @param amount The amount that will be burnt.
    */
   function _burn(address account, uint256 amount) internal {
-    require(account != 0);
+    require(account != address(0));
     require(amount <= _balances[account]);
 
     _totalSupply = _totalSupply.sub(amount);

--- a/contracts/token/ERC20/ERC20Detailed.sol
+++ b/contracts/token/ERC20/ERC20Detailed.sol
@@ -13,7 +13,7 @@ contract ERC20Detailed is IERC20 {
   string private _symbol;
   uint8 private _decimals;
 
-  constructor(string name, string symbol, uint8 decimals) public {
+  constructor(string memory name, string memory symbol, uint8 decimals) public {
     _name = name;
     _symbol = symbol;
     _decimals = decimals;
@@ -22,14 +22,14 @@ contract ERC20Detailed is IERC20 {
   /**
    * @return the name of the token.
    */
-  function name() public view returns(string) {
+  function name() public view returns (string memory) {
     return _name;
   }
 
   /**
    * @return the symbol of the token.
    */
-  function symbol() public view returns(string) {
+  function symbol() public view returns (string memory) {
     return _symbol;
   }
 

--- a/contracts/token/ERC721/ERC721Full.sol
+++ b/contracts/token/ERC721/ERC721Full.sol
@@ -11,7 +11,7 @@ import "./ERC721Metadata.sol";
  * @dev see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
  */
 contract ERC721Full is ERC721, ERC721Enumerable, ERC721Metadata {
-  constructor(string name, string symbol) ERC721Metadata(name, symbol)
+  constructor(string memory name, string memory symbol) ERC721Metadata(name, symbol)
     public
   {
   }

--- a/contracts/token/ERC721/ERC721Holder.sol
+++ b/contracts/token/ERC721/ERC721Holder.sol
@@ -7,7 +7,7 @@ contract ERC721Holder is IERC721Receiver {
     address,
     address,
     uint256,
-    bytes
+    bytes memory
   )
     public
     returns(bytes4)

--- a/contracts/token/ERC721/ERC721Mintable.sol
+++ b/contracts/token/ERC721/ERC721Mintable.sol
@@ -29,7 +29,7 @@ contract ERC721Mintable is ERC721Full, MinterRole {
   function mintWithTokenURI(
     address to,
     uint256 tokenId,
-    string tokenURI
+    string memory tokenURI
   )
     public
     onlyMinter


### PR DESCRIPTION
All the remaining changes for `truffle compile` to succeed.

* Some are straightforward, like inserting `memory` keyword where necessary, casting a contract/interface to `address` where necessary, etc. 
* Others involving `address payable` might be slightly opinionated in some instances.
* `<address>.call` now returns also the call return-value — I simply discard it.